### PR TITLE
save elapsed time into neptune

### DIFF
--- a/tools/eval_tsdr.py
+++ b/tools/eval_tsdr.py
@@ -191,7 +191,10 @@ def eval_tsdr(run: neptune.Run, cfg: DictConfig):
         index=['chaos_type', 'chaos_comp', 'step']
     ).dropna()
     tests_df = pd.DataFrame(
-        columns=['chaos_type', 'chaos_comp', 'metrics_file', 'step', 'ok', 'num_series', 'found_metrics', 'grafana_dashboard_url'],
+        columns=[
+            'chaos_type', 'chaos_comp', 'metrics_file', 'step', 'ok',
+            'num_series', 'elapsedTime', 'found_metrics', 'grafana_dashboard_url'
+        ],
         index=['chaos_type', 'chaos_comp', 'metrics_file', 'grafana_dashboard_url', 'step'],
     ).dropna()
 
@@ -265,7 +268,8 @@ def eval_tsdr(run: neptune.Run, cfg: DictConfig):
                     pd.Series(
                         [
                             chaos_type, chaos_comp, metrics_file, step, ok,
-                            num_series_str, ','.join(found_metrics), grafana_dashboard_url,
+                            num_series_str, elapsedTime[step],
+                            ','.join(found_metrics), grafana_dashboard_url,
                         ], index=tests_df.columns,
                     ), ignore_index=True,
                 )

--- a/tools/eval_tsdr.py
+++ b/tools/eval_tsdr.py
@@ -164,6 +164,7 @@ def get_scores_by_index(scores_df: pd.DataFrame, indexes: list[str]) -> pd.DataF
         'fn': 'sum',
         'tp': 'sum',
         'reduction_rate': 'mean',
+        'elapsed_time': 'mean',
     })
     df['accuracy'] = (df['tp'] + df['tn']) / (df['tn'] + df['fp'] + df['fn'] + df['tp'])
     return df
@@ -187,13 +188,13 @@ def eval_tsdr(run: neptune.Run, cfg: DictConfig):
     scores_df = pd.DataFrame(
         columns=['chaos_type', 'chaos_comp', 'step',
                  'tn', 'fp', 'fn', 'tp', 'accuracy', 'recall',
-                 'num_series', 'reduction_rate'],
+                 'num_series', 'reduction_rate', 'elapsed_time'],
         index=['chaos_type', 'chaos_comp', 'step']
     ).dropna()
     tests_df = pd.DataFrame(
         columns=[
             'chaos_type', 'chaos_comp', 'metrics_file', 'step', 'ok',
-            'num_series', 'elapsedTime', 'found_metrics', 'grafana_dashboard_url'
+            'num_series', 'elapsed_time', 'found_metrics', 'grafana_dashboard_url'
         ],
         index=['chaos_type', 'chaos_comp', 'metrics_file', 'grafana_dashboard_url', 'step'],
     ).dropna()
@@ -202,6 +203,7 @@ def eval_tsdr(run: neptune.Run, cfg: DictConfig):
         y_true_by_step: dict[str, list[int]] = defaultdict(lambda: list())
         y_pred_by_step: dict[str, list[int]] = defaultdict(lambda: list())
         num_series: dict[str, list[float]] = defaultdict(lambda: list())
+        elapsed_time: dict[str, list[float]] = defaultdict(lambda: list())
 
         for (metrics_file, grafana_dashboard_url), data_df in sub_df.groupby(level=[2, 3]):
             record = DatasetRecord(chaos_type, chaos_comp, metrics_file, data_df)
@@ -240,11 +242,12 @@ def eval_tsdr(run: neptune.Run, cfg: DictConfig):
                     tsdr.ar_based_ad_model, **tsdr_param,
                 )
 
-            elapsedTime, reduced_df_by_step, metrics_dimension, clustering_info = reducer.run(
+            elapsed_time_by_step, reduced_df_by_step, metrics_dimension, clustering_info = reducer.run(
                 series=data_df,
                 max_workers=cpu_count(),
             )
 
+            elapsed_time_by_step['total'] = elapsed_time_by_step['step1'] + elapsed_time_by_step['step2']
             num_series_each_step: dict[str, float] = {
                 'total': metrics_dimension['total'][0],
                 'step1': metrics_dimension['total'][1],
@@ -264,11 +267,12 @@ def eval_tsdr(run: neptune.Run, cfg: DictConfig):
                 y_true_by_step[step].append(1)
                 y_pred_by_step[step].append(1 if ok else 0)
                 num_series[step].append(num_series_each_step[step])
+                elapsed_time[step].append(elapsed_time_by_step[step])
                 tests_df = tests_df.append(
                     pd.Series(
                         [
                             chaos_type, chaos_comp, metrics_file, step, ok,
-                            num_series_str, elapsedTime[step],
+                            num_series_str, elapsed_time_by_step[step],
                             ','.join(found_metrics), grafana_dashboard_url,
                         ], index=tests_df.columns,
                     ), ignore_index=True,
@@ -313,11 +317,12 @@ def eval_tsdr(run: neptune.Run, cfg: DictConfig):
             accuracy: float = accuracy_score(y_true, y_pred)
             recall: float = recall_score(y_true, y_pred)
             mean_reduction_rate: float = 1 - np.mean(np.divide(num_series[step], num_series['total']))
+            mean_elapsed_time: float = np.mean(elapsed_time[step])
             scores_df = scores_df.append(
                 pd.Series([
                     chaos_type, chaos_comp, step,
                     tn, fp, fn, tp, accuracy, recall,
-                    mean_num_series_str, mean_reduction_rate],
+                    mean_num_series_str, mean_reduction_rate, mean_elapsed_time],
                     index=scores_df.columns,
                 ), ignore_index=True,
             )
@@ -340,6 +345,11 @@ def eval_tsdr(run: neptune.Run, cfg: DictConfig):
         'mean': scores_df['reduction_rate'].mean(),
         'max': scores_df['reduction_rate'].max(),
         'min': scores_df['reduction_rate'].min(),
+    }
+    run['scores/elapsed_time'] = {
+        'mean': scores_df['elapsed_time'].mean(),
+        'max': scores_df['elapsed_time'].max(),
+        'min': scores_df['elapsed_time'].min(),
     }
     run['scores/table'].upload(neptune.types.File.as_html(scores_df))
 

--- a/tsdr/outlierdetection/ar.py
+++ b/tsdr/outlierdetection/ar.py
@@ -10,7 +10,7 @@ class AROutlierDetector:
 
     def score(self, x: np.ndarray, regression: str = 'c', ic: str = 'aic') -> list[float]:
         maxlag = int(x.size * 0.2) if self.maxlag == 0 else self.maxlag
-        sel = ar_select_order(x, maxlag=maxlag, trend=regression, ic=ic)
+        sel = ar_select_order(x, maxlag=maxlag, trend=regression, ic=ic, old_names=False)
         model_fit = sel.model.fit()
         r: int = 0
         if model_fit.ar_lags is None or len(model_fit.ar_lags) > 0:

--- a/tsdr/tsdr.py
+++ b/tsdr/tsdr.py
@@ -118,24 +118,24 @@ class Tsdr:
         metrics_dimension: dict[str, Any] = aggregate_dimension(series)
 
         # step1
-        start: float = time.perf_counter()
+        start: float = time.time()
 
         reduced_series1 = self.reduce_univariate_series(series, max_workers)
 
-        time_adf: float = round(time.perf_counter() - start, 2)
+        time_adf: float = round(time.time() - start, 2)
         metrics_dimension = util.count_metrics(
             metrics_dimension, reduced_series1, 1)
         metrics_dimension["total"].append(len(reduced_series1.columns))
 
         # step2
-        start: float = time.perf_counter()
+        start: float = time.time()
 
         reduced_series2, clustering_info = self.reduce_multivariate_series(
             reduced_series1.copy(), services, max_workers,
             self.params['tsifter_step2_clustering_threshold'],
         )
 
-        time_clustering: float = round(time.perf_counter() - start, 2)
+        time_clustering: float = round(time.time() - start, 2)
         metrics_dimension = util.count_metrics(metrics_dimension, reduced_series2, 2)
         metrics_dimension["total"].append(len(reduced_series2.columns))
 

--- a/tsdr/tsdr.py
+++ b/tsdr/tsdr.py
@@ -118,24 +118,24 @@ class Tsdr:
         metrics_dimension: dict[str, Any] = aggregate_dimension(series)
 
         # step1
-        start = time.time()
+        start: float = time.time()
 
         reduced_series1 = self.reduce_univariate_series(series, max_workers)
 
-        time_adf = round(time.time() - start, 2)
+        time_adf: float = round(time.time() - start, 2)
         metrics_dimension = util.count_metrics(
             metrics_dimension, reduced_series1, 1)
         metrics_dimension["total"].append(len(reduced_series1.columns))
 
         # step2
-        start = time.time()
+        start: float = time.time()
 
         reduced_series2, clustering_info = self.reduce_multivariate_series(
             reduced_series1.copy(), services, max_workers,
             self.params['tsifter_step2_clustering_threshold'],
         )
 
-        time_clustering = round(time.time() - start, 2)
+        time_clustering: float = round(time.time() - start, 2)
         metrics_dimension = util.count_metrics(metrics_dimension, reduced_series2, 2)
         metrics_dimension["total"].append(len(reduced_series2.columns))
 

--- a/tsdr/tsdr.py
+++ b/tsdr/tsdr.py
@@ -118,24 +118,24 @@ class Tsdr:
         metrics_dimension: dict[str, Any] = aggregate_dimension(series)
 
         # step1
-        start: float = time.time()
+        start: float = time.perf_counter()
 
         reduced_series1 = self.reduce_univariate_series(series, max_workers)
 
-        time_adf: float = round(time.time() - start, 2)
+        time_adf: float = round(time.perf_counter() - start, 2)
         metrics_dimension = util.count_metrics(
             metrics_dimension, reduced_series1, 1)
         metrics_dimension["total"].append(len(reduced_series1.columns))
 
         # step2
-        start: float = time.time()
+        start: float = time.perf_counter()
 
         reduced_series2, clustering_info = self.reduce_multivariate_series(
             reduced_series1.copy(), services, max_workers,
             self.params['tsifter_step2_clustering_threshold'],
         )
 
-        time_clustering: float = round(time.time() - start, 2)
+        time_clustering: float = round(time.perf_counter() - start, 2)
         metrics_dimension = util.count_metrics(metrics_dimension, reduced_series2, 2)
         metrics_dimension["total"].append(len(reduced_series2.columns))
 


### PR DESCRIPTION
- tsdr: pass parameters with **kwargs
- tsdr: refactor prepare_services_list
- tsdr: add typing for aggregate_metrics
- tsdr: wrap tsdr processing code as class Tsdr
- tsdr: enable to replace function for detecting anomaly of univariate series
- tsdr: remove unit_root_model param
- tsdr: enable to specify model combination
- tsdr: fixed forgotten change reflection in test code
- tsdr: give typing whenever possible
- tools: skip image generation if neptune.mode == debug
- tsdr: refactor the details
- tests: add white noise series in test code
- tsdr: enable to take log in unit_root_based_model
- tests: enable to discover the param combinations where all cases are passed
- notebooks: update
- tsdr: add an option for taking log
- tests: add post_cv variations
- tsdr: use AR lag as knn's window size
- notebooks: update
- tsdr: fix trivial issues in knn
- tsdr: update default config
- notebooks: try hotteling t2 to distinguish white noise and short spike
- tsdr: support hotteling t2 as post_od_model
- tools: support post_od_model params
- tsdr: remove 'import re'
- conf: increase distance threshold in step2
- notebooks: add ar-based anomaly detection
- tsdr: add ar-based outlier detector
- notebooks: update
- tsdr: enable ar outlier detector to pass datasets
- tsdr: prepare ar_based_ad_model func
- tools,conf: enable to choose ar based ad model
- tests: add test for ar_abomaly_score
- notebooks,tests: visualize testcases
- tests: add ar_regression pytest param
- notebooks: dignose test failure
- tsdr: fix calculation of prediction error in AR model
- notebooks: update
- tsdr: fix param name
- tests: look for upper and lower thresholds
- tools: fix an issue where the script did not upload parameters to neptune
- tsdr: supress warnings generated in AR outlier detector
- tsdr: add missing typing
- tsdr: use time.perf_counter() to improve resolution
- tools: save elapsedTime of each test into neptune
- tsdr: still use absolute time
- tools: save elapsedTime as score into neptune
