### PR TITLE
fitting chi2 dist ar based ad

### DIFF
--- a/conf/tsdr/step1/ar_based_ad.yaml
+++ b/conf/tsdr/step1/ar_based_ad.yaml
@@ -1,4 +1,4 @@
 model_name: ar_based_ad
 ar_regression: ct
-ar_anomaly_score_threshold: 10
+ar_anomaly_score_threshold: 0.01
 cv_threshold: 0.05

--- a/conf/tsdr/step1/ar_based_ad.yaml
+++ b/conf/tsdr/step1/ar_based_ad.yaml
@@ -1,4 +1,4 @@
 model_name: ar_based_ad
-ar_regression: ct
+ar_regression: c
 ar_anomaly_score_threshold: 0.01
 cv_threshold: 0.05

--- a/conf/tsdr/step1/df.yaml
+++ b/conf/tsdr/step1/df.yaml
@@ -1,9 +1,9 @@
 model_name: unit_root_test
+pre_cv: true
+cv_threshold: 0.05
 take_log: false
 unit_root_model: adf
 unit_root_alpha: 0.01
 unit_root_regression: c
-post_cv: true
-cv_threshold: 0.05
 post_od_model: 'hotelling' # outlier detection (od) model
 post_od_threshold: 0.01

--- a/tools/eval_tsdr.py
+++ b/tools/eval_tsdr.py
@@ -220,12 +220,12 @@ def eval_tsdr(run: neptune.Run, cfg: DictConfig):
             }
             if cfg.step1.model_name == 'unit_root_test':
                 tsdr_param.update({
+                    'tsifter_step1_pre_cv': cfg.step1.pre_cv,
+                    'tsifter_step1_cv_threshold': cfg.step1.cv_threshold,
                     'tsifter_step1_take_log': cfg.step1.take_log,
                     'tsifter_step1_unit_root_model': cfg.step1.unit_root_model,
                     'tsifter_step1_unit_root_alpha': cfg.step1.unit_root_alpha,
                     'tsifter_step1_unit_root_regression': cfg.step1.unit_root_regression,
-                    'tsifter_step1_post_cv': cfg.step1.post_cv,
-                    'tsifter_step1_cv_threshold': cfg.step1.cv_threshold,
                     'tsifter_step1_post_od_model': cfg.step1.post_od_model,
                     'tsifter_step1_post_od_threshold': cfg.step1.post_od_threshold,
                 })

--- a/tools/eval_tsdr.py
+++ b/tools/eval_tsdr.py
@@ -360,8 +360,8 @@ def eval_tsdr(run: neptune.Run, cfg: DictConfig):
 
     logger.info(tests_df.head())
     logger.info(scores_df.head())
-    logger.info(scores_df_by_chaos_type.head())
-    logger.info(scores_df_by_chaos_comp.head())
+    logger.info(scores_df_by_chaos_type)
+    logger.info(scores_df_by_chaos_comp)
     logger.info(clustering_df.head())
 
 

--- a/tools/verify_tsdr_univariate_model.py
+++ b/tools/verify_tsdr_univariate_model.py
@@ -86,7 +86,9 @@ def verify_ar_based_ad_model():
 
 
 def main():
+    print("--> unit_root_test")
     verify_unit_root_test_model()
+    print("--> ar_based_ad")
     verify_ar_based_ad_model()
 
 

--- a/tools/verify_tsdr_univariate_model.py
+++ b/tools/verify_tsdr_univariate_model.py
@@ -36,12 +36,12 @@ def verify_unit_root_test_model():
         for case in testcases_of_sockshop:
             got: bool = tsdr.unit_root_based_model(
                 series=np.array(case['datapoints']),
+                tsifter_step1_pre_cv=post_cv,
+                tsifter_step1_cv_threshold=cv_threshold,
                 tsifter_step1_take_log=take_log,
                 tsifter_step1_unit_root_model=unit_root_model,
                 tsifter_step1_unit_root_alpla=unit_root_alpha,
                 tsifter_step1_unit_root_regression=unit_root_regression,
-                tsifter_step1_post_cv=post_cv,
-                tsifter_step1_cv_threshold=cv_threshold,
                 tsifter_step1_post_knn=post_knn,
                 tsifter_step1_knn_threshold=knn_threshold,
             )

--- a/tsdr/outlierdetection/ar.py
+++ b/tsdr/outlierdetection/ar.py
@@ -8,7 +8,7 @@ class AROutlierDetector:
     def __init__(self, maxlag: int = 0):
         self.maxlag = maxlag
 
-    def score(self, x: np.ndarray, regression: str = 'c', ic: str = 'aic') -> list[float]:
+    def score(self, x: np.ndarray, regression: str = 'c', ic: str = 'aic', include_nan: bool = False) -> list[float]:
         maxlag = int(x.size * 0.2) if self.maxlag == 0 else self.maxlag
         sel = ar_select_order(x, maxlag=maxlag, trend=regression, ic=ic, old_names=False)
         model_fit = sel.model.fit()
@@ -25,7 +25,7 @@ class AROutlierDetector:
             if i >= preds.size:
                 break
             scores.append((xi - preds[i]) ** 2 / sig2)
-        return [np.nan * r] + scores
+        return [np.nan * r] + scores if include_nan else scores
 
     def find_anomalies(self, x: np.ndarray, threshold: float) -> list[float]:
         return [s for s in self.score(x) if s >= threshold]

--- a/tsdr/outlierdetection/ar.py
+++ b/tsdr/outlierdetection/ar.py
@@ -1,4 +1,5 @@
 import numpy as np
+from scipy.stats import chi2
 from statsmodels.tsa.ar_model import ar_select_order
 
 
@@ -27,5 +28,14 @@ class AROutlierDetector:
             scores.append((xi - preds[i]) ** 2 / sig2)
         return [np.nan * r] + scores if include_nan else scores
 
-    def find_anomalies(self, x: np.ndarray, threshold: float) -> list[float]:
+    def detect(self, x: np.ndarray, threshold: float) -> list[float]:
         return [s for s in self.score(x) if s >= threshold]
+
+    def detect_by_fitting_dist(self, x: np.ndarray, threshold: float, **kwargs) -> list[tuple[int, float]]:
+        scores = self.score(x, **kwargs)
+        abn_th = chi2.interval(1-threshold, 1)[1]
+        anomalies: list[tuple[int, float]] = []
+        for i, a in enumerate(scores):
+            if a > abn_th:
+                anomalies.append((i, a))
+        return anomalies

--- a/tsdr/tsdr.py
+++ b/tsdr/tsdr.py
@@ -44,6 +44,11 @@ def unit_root_based_model(series: np.ndarray, **kwargs: Any) -> bool:
     maxlag: int = kwargs.get('tsifter_step1_unit_root_max_lags', None)
     autolag = kwargs.get('tsifter_step1_unit_root_autolag', None)
 
+    if kwargs.get('tsifter_step1_pre_cv', False):
+        cv_threshold = kwargs.get('tsifter_step1_cv_threshold', 0.01)
+        if not has_variation(np.diff(series), cv_threshold) or not has_variation(series, cv_threshold):
+            return False
+
     def log_or_nothing(x: np.ndarray) -> np.ndarray:
         if kwargs.get('tsifter_step1_take_log', False):
             return np.log1p(x)
@@ -65,11 +70,7 @@ def unit_root_based_model(series: np.ndarray, **kwargs: Any) -> bool:
             warnings.warn(str(e))
             return False
     if pvalue >= kwargs.get('tsifter_step1_unit_root_alpha', 0.01):
-        if kwargs.get('tsifter_step1_post_cv', False):
-            # run df-test for differences of data_{n} and data{n-1} for liner trend series
-            cv_threshold = kwargs.get('tsifter_step1_cv_threshold', 0.01)
-            if has_variation(np.diff(series), cv_threshold) and has_variation(series, cv_threshold):
-                return True
+        return True
     else:
         # Post outlier detection
         odmodel: str = kwargs.get('tsifter_step1_post_od_model', 'knn')

--- a/tsdr/tsdr.py
+++ b/tsdr/tsdr.py
@@ -93,9 +93,9 @@ def ar_based_ad_model(series: np.ndarray, **kwargs: Any) -> bool:
     if not has_variation(np.diff(series), cv_threshold) or not has_variation(series, cv_threshold):
         return False
 
-    ar_threshold: float = kwargs.get('tsifter_step1_ar_anomaly_score_threshold', 10.0)
+    ar_threshold: float = kwargs.get('tsifter_step1_ar_anomaly_score_threshold', 0.01)
     ar = AROutlierDetector()
-    anomalies = ar.find_anomalies(scipy.stats.zscore(series), ar_threshold)
+    anomalies = ar.detect_by_fitting_dist(scipy.stats.zscore(series), threshold=ar_threshold)
     if len(anomalies) > 0:
         return True
     return False

--- a/tsdr/tsdr.py
+++ b/tsdr/tsdr.py
@@ -95,7 +95,11 @@ def ar_based_ad_model(series: np.ndarray, **kwargs: Any) -> bool:
 
     ar_threshold: float = kwargs.get('tsifter_step1_ar_anomaly_score_threshold', 0.01)
     ar = AROutlierDetector()
-    anomalies = ar.detect_by_fitting_dist(scipy.stats.zscore(series), threshold=ar_threshold)
+    anomalies = ar.detect_by_fitting_dist(
+        scipy.stats.zscore(series),
+        threshold=ar_threshold,
+        regression=kwargs.get('tsifter_step1_ar_regression', 'c'),
+    )
     if len(anomalies) > 0:
         return True
     return False


### PR DESCRIPTION
- tsdr: pass parameters with **kwargs
- tsdr: refactor prepare_services_list
- tsdr: add typing for aggregate_metrics
- tsdr: wrap tsdr processing code as class Tsdr
- tsdr: enable to replace function for detecting anomaly of univariate series
- tsdr: remove unit_root_model param
- tsdr: enable to specify model combination
- tsdr: fixed forgotten change reflection in test code
- tsdr: give typing whenever possible
- tools: skip image generation if neptune.mode == debug
- tsdr: refactor the details
- tests: add white noise series in test code
- tsdr: enable to take log in unit_root_based_model
- tests: enable to discover the param combinations where all cases are passed
- notebooks: update
- tsdr: add an option for taking log
- tests: add post_cv variations
- tsdr: use AR lag as knn's window size
- notebooks: update
- tsdr: fix trivial issues in knn
- tsdr: update default config
- notebooks: try hotteling t2 to distinguish white noise and short spike
- tsdr: support hotteling t2 as post_od_model
- tools: support post_od_model params
- tsdr: remove 'import re'
- conf: increase distance threshold in step2
- notebooks: add ar-based anomaly detection
- tsdr: add ar-based outlier detector
- notebooks: update
- tsdr: enable ar outlier detector to pass datasets
- tsdr: prepare ar_based_ad_model func
- tools,conf: enable to choose ar based ad model
- tests: add test for ar_abomaly_score
- notebooks,tests: visualize testcases
- tests: add ar_regression pytest param
- notebooks: dignose test failure
- tsdr: fix calculation of prediction error in AR model
- notebooks: update
- tsdr: fix param name
- tests: look for upper and lower thresholds
- tools: fix an issue where the script did not upload parameters to neptune
- tsdr: supress warnings generated in AR outlier detector
- tsdr: add missing typing
- tsdr: use time.perf_counter() to improve resolution
- tools: save elapsedTime of each test into neptune
- tsdr: still use absolute time
- tools: save elapsedTime as score into neptune
- tsdr: move tests.testseries -> tsdr.testseries
- tools: add script to verify tsdr univariate model
- tests: remove old test script
- kick to install depsin ci
- Revert "kick to install depsin ci"
- tests: add test for outlierdetection.ar
- tests: add test for outlierdetection.knn
- tests: add cache key to clear cache in github actions
- tests: fix that the test code didn't compare want and got
- tsdr: move cv filtering before running unit root test
- tools: display all rows of some dataframes
- tools: print the type of model
- tsdr: add include_nan option for ar.score()
- tsdr: add method to fit anomaly scores to chi2 distribution
- tsdr: use detect_by_fitting_dist in AR-based AD
- tsdr: fix the issue where it cannot pass tsifter_step1_ar_regression
