### PR TITLE
binary-based anomaly score

### DIFF
--- a/conf/tsdr/step2/default.yaml
+++ b/conf/tsdr/step2/default.yaml
@@ -1,2 +1,2 @@
 dist_threshold: 0.01
-use_anomaly_score: false
+clustered_series_type: 'raw' # 'anomaly_score' or 'binary_anomaly_score'

--- a/tools/eval_tsdr.py
+++ b/tools/eval_tsdr.py
@@ -253,7 +253,7 @@ def eval_tsdr(run: neptune.Run, cfg: DictConfig):
             reducer: tsdr.Tsdr
             tsdr_param = {
                 'tsifter_step2_clustering_threshold': cfg.step2.dist_threshold,
-                'tsifter_step2_use_anomaly_score': cfg.step2.use_anomaly_score,
+                'tsifter_step2_clustered_series_type': cfg.step2.clustered_series_type,
             }
             if cfg.step1.model_name == 'unit_root_test':
                 tsdr_param.update({
@@ -413,7 +413,7 @@ def main(cfg: DictConfig) -> None:
     params = {
         'exclude_middleware_metrics': cfg.exclude_middleware_metrics,
         'step2_dist_threshold': cfg.step2.dist_threshold,
-        'step2_use_anomaly_score': cfg.step2.use_anomaly_score,
+        'step2_clustered_series_type': cfg.step2.clustered_series_type,
     }
     if cfg.step1.model_name == 'unit_root_test':
         params.update({

--- a/tsdr/outlierdetection/ar.py
+++ b/tsdr/outlierdetection/ar.py
@@ -55,10 +55,14 @@ class AROutlierDetector:
             scores[r + i] = (xi - pred) ** 2 / sig2
         return scores, preds, model_fit
 
-    def detect_by_fitting_dist(self, scores: np.ndarray, threshold: float) -> list[tuple[int, float]]:
+    def detect_by_fitting_dist(
+        self,
+        scores: np.ndarray,
+        threshold: float,
+    ) -> tuple[list[tuple[int, float]], np.ndarray]:
         abn_th = chi2.interval(1-threshold, 1)[1]
         anomalies: list[tuple[int, float]] = []
         for i, a in enumerate(scores):
             if a > abn_th:
                 anomalies.append((i, a))
-        return anomalies
+        return anomalies, abn_th

--- a/tsdr/outlierdetection/ar.py
+++ b/tsdr/outlierdetection/ar.py
@@ -59,7 +59,7 @@ class AROutlierDetector:
         self,
         scores: np.ndarray,
         threshold: float,
-    ) -> tuple[list[tuple[int, float]], np.ndarray]:
+    ) -> tuple[list[tuple[int, float]], float]:
         abn_th = chi2.interval(1-threshold, 1)[1]
         anomalies: list[tuple[int, float]] = []
         for i, a in enumerate(scores):

--- a/tsdr/tsdr.py
+++ b/tsdr/tsdr.py
@@ -264,10 +264,8 @@ def reduce_series_with_cv(data_df: pd.DataFrame, cv_threshold: float = 0.002):
 def hierarchical_clustering(
     target_df: pd.DataFrame, dist_func, dist_threshold: float,
 ) -> tuple[dict[str, Any], list[str]]:
-    series = target_df.values.T
-    norm_series: np.ndarray = util.z_normalization(series)
-    dist = pdist(norm_series, metric=dist_func)
-    # distance_list.extend(dist)
+    series: np.ndarray = target_df.apply(scipy.stats.zscore).values.T
+    dist = pdist(series, metric=dist_func)
     dist_matrix: np.ndarray = squareform(dist)
     z: np.ndarray = linkage(dist, method="single", metric=dist_func)
     labels: np.ndarray = fcluster(z, t=dist_threshold, criterion="distance")
@@ -363,7 +361,7 @@ def kshape_clustering(
 ) -> tuple[dict[str, Any], list[str]]:
     future_list = []
 
-    data: np.ndarray = util.z_normalization(target_df.values.T)
+    data: np.ndarray = target_df.apply(scipy.stats.zscore).values.T
     for n in np.arange(2, data.shape[0]):
         future_list.append(
             executor.submit(

--- a/tsdr/tsdr.py
+++ b/tsdr/tsdr.py
@@ -141,8 +141,8 @@ def ar_based_ad_model(series: np.ndarray, **kwargs: Any) -> UnivariateSeriesRedu
         raise ValueError(f"scores must contain only finite values. {scores}")
     outliers, abn_th = ar.detect_by_fitting_dist(scores, threshold=ar_threshold)
     if len(outliers) > 0:
-        return UnivariateSeriesReductionResult(series, has_kept=True, anomaly_scores=scores)
-    return UnivariateSeriesReductionResult(series, has_kept=False, anomaly_scores=scores)
+        return UnivariateSeriesReductionResult(series, has_kept=True, anomaly_scores=scores, abn_th=abn_th)
+    return UnivariateSeriesReductionResult(series, has_kept=False, anomaly_scores=scores, abn_th=abn_th)
 
 
 class Tsdr:

--- a/tsdr/tsdr.py
+++ b/tsdr/tsdr.py
@@ -43,16 +43,19 @@ class UnivariateSeriesReductionResult:
     _original_series: np.ndarray
     _has_kept: bool
     _anomaly_scores: np.ndarray
+    _abn_th: float
 
     def __init__(
         self,
         original_series: np.ndarray,
         has_kept: bool,
         anomaly_scores: np.ndarray = np.array([]),
+        abn_th: float = 0.0,
     ) -> None:
         self._original_series = original_series
         self._has_kept = has_kept
         self._anomaly_scores = anomaly_scores
+        self._abn_th = abn_th
 
     @property
     def original_series(self):
@@ -65,6 +68,12 @@ class UnivariateSeriesReductionResult:
     @property
     def anomaly_scores(self):
         return self._anomaly_scores
+
+    def binary_scores(self) -> np.ndarray:
+        bin_scores = np.empty(self.anomaly_scores.size, dtype=np.uint8)
+        bin_scores[np.argwhere(self.anomaly_scores <= self._abn_th)] = 0
+        bin_scores[np.argwhere(self.anomaly_scores > self._abn_th)] = 1
+        return bin_scores
 
 
 def unit_root_based_model(series: np.ndarray, **kwargs: Any) -> UnivariateSeriesReductionResult:
@@ -130,7 +139,7 @@ def ar_based_ad_model(series: np.ndarray, **kwargs: Any) -> UnivariateSeriesRedu
     )[0]
     if not np.all(np.isfinite(scores)):
         raise ValueError(f"scores must contain only finite values. {scores}")
-    outliers = ar.detect_by_fitting_dist(scores, threshold=ar_threshold)
+    outliers, abn_th = ar.detect_by_fitting_dist(scores, threshold=ar_threshold)
     if len(outliers) > 0:
         return UnivariateSeriesReductionResult(series, has_kept=True, anomaly_scores=scores)
     return UnivariateSeriesReductionResult(series, has_kept=False, anomaly_scores=scores)
@@ -161,7 +170,7 @@ class Tsdr:
         # step1
         start: float = time.time()
 
-        reduced_series1, anomaly_score_df = self.reduce_univariate_series(series, max_workers)
+        reduced_series1, step1_results = self.reduce_univariate_series(series, max_workers)
 
         time_adf: float = round(time.time() - start, 2)
         metrics_dimension = util.count_metrics(
@@ -169,8 +178,21 @@ class Tsdr:
         metrics_dimension["total"].append(len(reduced_series1.columns))
 
         # step2
-        df_before_clustering = anomaly_score_df \
-            if self.params['tsifter_step2_use_anomaly_score'] else reduced_series1
+        df_before_clustering: pd.DataFrame = pd.DataFrame()
+        series_type = self.params['tsifter_step2_clustered_series_type']
+        if series_type == 'raw':
+            df_before_clustering = reduced_series1
+        elif series_type == 'anomaly_score':
+            for name, res in step1_results.items():
+                if res.has_kept:
+                    df_before_clustering[name] = res.anomaly_scores
+        elif series_type == 'binary_anomaly_score':
+            for name, res in step1_results.items():
+                if res.has_kept:
+                    df_before_clustering[name] = res.binary_scores()
+        else:
+            raise ValueError(f'tsifter_step2_clustered_series_type is invalid {series_type}')
+
         start = time.time()
 
         reduced_series2, clustering_info = self.reduce_multivariate_series(
@@ -189,8 +211,8 @@ class Tsdr:
         self,
         useries: pd.DataFrame,
         n_workers: int,
-    ) -> tuple[pd.DataFrame, pd.DataFrame]:
-        anomaly_score_df = pd.DataFrame()
+    ) -> tuple[pd.DataFrame, dict[str, UnivariateSeriesReductionResult]]:
+        results: dict[str, UnivariateSeriesReductionResult] = {}
         with futures.ProcessPoolExecutor(max_workers=n_workers) as executor:
             future_to_col = {}
             for col in useries.columns:
@@ -203,11 +225,10 @@ class Tsdr:
             for future in futures.as_completed(future_to_col):
                 col = future_to_col[future]
                 result: UnivariateSeriesReductionResult = future.result()
+                results[col] = result
                 if result.has_kept:
                     reduced_cols.append(col)
-                    if len(result.anomaly_scores) > 0:
-                        anomaly_score_df[col] = result.anomaly_scores
-        return useries[reduced_cols], anomaly_score_df
+        return useries[reduced_cols], results
 
     def reduce_multivariate_series(
         self,

--- a/tsdr/util/util.py
+++ b/tsdr/util/util.py
@@ -1,16 +1,6 @@
 from typing import Any
 
-import numpy as np
 import pandas as pd
-
-
-def z_normalization(data):
-    arr = []
-    for d in data:
-        mean = d.mean()
-        std = d.std()
-        arr.append((d - mean) / std)
-    return np.array(arr)
 
 
 def count_metrics(metrics_dimension: dict[str, Any], dataframe: pd.DataFrame, n: int) -> dict[str, Any]:


### PR DESCRIPTION
- tsdr: pass parameters with **kwargs
- tsdr: refactor prepare_services_list
- tsdr: add typing for aggregate_metrics
- tsdr: wrap tsdr processing code as class Tsdr
- tsdr: enable to replace function for detecting anomaly of univariate series
- tsdr: remove unit_root_model param
- tsdr: enable to specify model combination
- tsdr: fixed forgotten change reflection in test code
- tsdr: give typing whenever possible
- tools: skip image generation if neptune.mode == debug
- tsdr: refactor the details
- tests: add white noise series in test code
- tsdr: enable to take log in unit_root_based_model
- tests: enable to discover the param combinations where all cases are passed
- notebooks: update
- tsdr: add an option for taking log
- tests: add post_cv variations
- tsdr: use AR lag as knn's window size
- notebooks: update
- tsdr: fix trivial issues in knn
- tsdr: update default config
- notebooks: try hotteling t2 to distinguish white noise and short spike
- tsdr: support hotteling t2 as post_od_model
- tools: support post_od_model params
- tsdr: remove 'import re'
- conf: increase distance threshold in step2
- notebooks: add ar-based anomaly detection
- tsdr: add ar-based outlier detector
- notebooks: update
- tsdr: enable ar outlier detector to pass datasets
- tsdr: prepare ar_based_ad_model func
- tools,conf: enable to choose ar based ad model
- tests: add test for ar_abomaly_score
- notebooks,tests: visualize testcases
- tests: add ar_regression pytest param
- notebooks: dignose test failure
- tsdr: fix calculation of prediction error in AR model
- notebooks: update
- tsdr: fix param name
- tests: look for upper and lower thresholds
- tools: fix an issue where the script did not upload parameters to neptune
- tsdr: supress warnings generated in AR outlier detector
- tsdr: add missing typing
- tsdr: use time.perf_counter() to improve resolution
- tools: save elapsedTime of each test into neptune
- tsdr: still use absolute time
- tools: save elapsedTime as score into neptune
- tsdr: move tests.testseries -> tsdr.testseries
- tools: add script to verify tsdr univariate model
- tests: remove old test script
- kick to install depsin ci
- Revert "kick to install depsin ci"
- tests: add test for outlierdetection.ar
- tests: add test for outlierdetection.knn
- tests: add cache key to clear cache in github actions
- tests: fix that the test code didn't compare want and got
- tsdr: move cv filtering before running unit root test
- tools: display all rows of some dataframes
- tools: print the type of model
- tsdr: add include_nan option for ar.score()
- tsdr: add method to fit anomaly scores to chi2 distribution
- tsdr: use detect_by_fitting_dist in AR-based AD
- tsdr: fix the issue where it cannot pass tsifter_step1_ar_regression
- tools: rename
- tools: add utility script to get datapoints
- tsdr: fix typo
- tools: enable to print compact dictionary in get_datapoints
- tools: fix indent
- tsdr: perform clustering in each type of metric
- tests: fix test code not catched up the previous change in the body code
- use make test in CI
- tsdr: refactor to access predicted_mean member
- tsdr: use zip instead of enumerate
- tsdr: make scores passable in AR model
- tsdr: introduce UnivariateSeriesReductionResult to pass anomaly scores to step2
- tsdr: set step1: ar_based_ad as default
- tsdr: fill_value with float to fit the size of original series in AR
- tsdr: add option to enable anomaly score clustering
- tsdr: fixed forgotten change reflection in test code
- tests: arrange code
- tsdr: fix typing mismatch error
- tsdr: copy dataframe if use_anomaly_score
- tsdr: enable to upload plots image if it is 'debug'
- tsdr: adjust indentation
- tsdr: fix typing
- tools: adjust indentation
- tools: fix the unnesessary and additional index columns
- tools: remove argparse
- tools: adjust indentation
- tools: fix an issue where it could not upload anomaly score plots in clustered_metrics if use_anomaly_score
- tools: warp processing related image uploader as time series plotter
- clean packages in CI
- tests: fix test in test_ar
- tests: add test_ar_outlier_detector_detect
- fix an issue of the absence of pytest because --no-dev option in CI
- tsdr: remove zscore
- tsdr: enable to set deterministic lag for AR
- notebooks: begin to diagnose misdetected series in AR
- tsdr: add an option for dynamic prediction in AR model
- notebooks: add try and errors for misdetected series with AR model
- tools: add an option of ar_dynamic_prediction
- tests: fix test failure because of the interface change
- tools: fix the conditional branch using enable_upload_plots
- lib: extend ground truth of pod-memory-hog injection
- lib: extend ground truth of pod-cpu-hog injection
- tests: fix test failure
- update neptune-client to v0.14.3
- tsdr: remove unused import
- tsdr: fix compared positions in AR outlier detection
- tsdr: raise error if scores include inf becasue clustering raise error
- tsdr: use scipy.stats.zscore
- tsdr: add an option to transform pre-clustered series into binary-based anomaly scores
