### PR TITLE
hamming distance

### DIFF
--- a/conf/tsdr/step2/default.yaml
+++ b/conf/tsdr/step2/default.yaml
@@ -1,2 +1,3 @@
 dist_threshold: 0.01
-clustered_series_type: 'raw' # 'anomaly_score' or 'binary_anomaly_score'
+clustered_series_type: 'raw' # 'raw', 'anomaly_score' or 'binary_anomaly_score'
+clustering_dist_type: 'sbd' # 'sbd' or 'hamming'

--- a/tools/eval_tsdr.py
+++ b/tools/eval_tsdr.py
@@ -254,6 +254,7 @@ def eval_tsdr(run: neptune.Run, cfg: DictConfig):
             tsdr_param = {
                 'tsifter_step2_clustering_threshold': cfg.step2.dist_threshold,
                 'tsifter_step2_clustered_series_type': cfg.step2.clustered_series_type,
+                'tsifter_step2_clustering_dist_type': cfg.step2.clustering_dist_type,
             }
             if cfg.step1.model_name == 'unit_root_test':
                 tsdr_param.update({
@@ -414,6 +415,7 @@ def main(cfg: DictConfig) -> None:
         'exclude_middleware_metrics': cfg.exclude_middleware_metrics,
         'step2_dist_threshold': cfg.step2.dist_threshold,
         'step2_clustered_series_type': cfg.step2.clustered_series_type,
+        'step2_clustering_dist_type': cfg.step2.clustering_dist_type,
     }
     if cfg.step1.model_name == 'unit_root_test':
         params.update({

--- a/tsdr/tsdr.py
+++ b/tsdr/tsdr.py
@@ -302,19 +302,7 @@ def reduce_series_with_cv(data_df: pd.DataFrame, cv_threshold: float = 0.002):
 def hierarchical_clustering(
     target_df: pd.DataFrame, dist_func: Callable, dist_threshold: float,
 ) -> tuple[dict[str, Any], list[str]]:
-<<<<<<< Updated upstream
-    series: np.ndarray = target_df.apply(scipy.stats.zscore).values.T
-    dist = pdist(series, metric=dist_func)
-=======
-<<<<<<< Updated upstream
-    series = target_df.values.T
-    norm_series: np.ndarray = util.z_normalization(series)
-    dist = pdist(norm_series, metric=dist_func)
-    # distance_list.extend(dist)
-=======
     dist = pdist(target_df.values.T, metric=dist_func)
->>>>>>> Stashed changes
->>>>>>> Stashed changes
     dist_matrix: np.ndarray = squareform(dist)
     z: np.ndarray = linkage(dist, method="single", metric=dist_func)
     labels: np.ndarray = fcluster(z, t=dist_threshold, criterion="distance")

--- a/tsdr/tsdr.py
+++ b/tsdr/tsdr.py
@@ -17,7 +17,7 @@ from arch.unitroot import PhillipsPerron
 from arch.utility.exceptions import InfeasibleTestException
 from lib.metrics import ROOT_METRIC_LABEL, check_cause_metrics
 from scipy.cluster.hierarchy import fcluster, linkage
-from scipy.spatial.distance import pdist, squareform
+from scipy.spatial.distance import hamming, pdist, squareform
 from statsmodels.tsa.stattools import adfuller
 
 from tsdr.clustering.kshape import kshape
@@ -197,6 +197,7 @@ class Tsdr:
 
         reduced_series2, clustering_info = self.reduce_multivariate_series(
             df_before_clustering.copy(), services, max_workers,
+            self.params['tsifter_step2_clustering_dist_type'],
             self.params['tsifter_step2_clustering_threshold'],
         )
 
@@ -235,6 +236,7 @@ class Tsdr:
         series: pd.DataFrame,
         services: list[str],
         n_workers: int,
+        dist_type: str,
         dist_threshold: float,
     ) -> tuple[pd.DataFrame, dict[str, Any]]:
         clustering_info: dict[str, Any] = {}
@@ -249,9 +251,24 @@ class Tsdr:
                 for target_df in [service_metrics_df, container_metrics_df, middleware_metrics_df]:
                     if len(target_df.columns) <= 1:
                         continue
-                    future_list.append(executor.submit(
-                        hierarchical_clustering, target_df, sbd, dist_threshold,
-                    ))
+                    future: futures.Future
+                    if dist_type == 'sbd':
+                        future = executor.submit(
+                            hierarchical_clustering,
+                            target_df.apply(scipy.stats.zscore),
+                            sbd,
+                            dist_threshold,
+                        )
+                    elif dist_type == 'hamming':
+                        future = executor.submit(
+                            hierarchical_clustering,
+                            target_df,
+                            hamming,
+                            dist_threshold,
+                        )
+                    else:
+                        raise ValueError('dist_func must be "sbd" or "hamming"')
+                    future_list.append(future)
             for future in futures.as_completed(future_list):
                 c_info, remove_list = future.result()
                 clustering_info.update(c_info)
@@ -283,10 +300,21 @@ def reduce_series_with_cv(data_df: pd.DataFrame, cv_threshold: float = 0.002):
 
 
 def hierarchical_clustering(
-    target_df: pd.DataFrame, dist_func, dist_threshold: float,
+    target_df: pd.DataFrame, dist_func: Callable, dist_threshold: float,
 ) -> tuple[dict[str, Any], list[str]]:
+<<<<<<< Updated upstream
     series: np.ndarray = target_df.apply(scipy.stats.zscore).values.T
     dist = pdist(series, metric=dist_func)
+=======
+<<<<<<< Updated upstream
+    series = target_df.values.T
+    norm_series: np.ndarray = util.z_normalization(series)
+    dist = pdist(norm_series, metric=dist_func)
+    # distance_list.extend(dist)
+=======
+    dist = pdist(target_df.values.T, metric=dist_func)
+>>>>>>> Stashed changes
+>>>>>>> Stashed changes
     dist_matrix: np.ndarray = squareform(dist)
     z: np.ndarray = linkage(dist, method="single", metric=dist_func)
     labels: np.ndarray = fcluster(z, t=dist_threshold, criterion="distance")

--- a/tsdr/tsdr.py
+++ b/tsdr/tsdr.py
@@ -260,6 +260,9 @@ class Tsdr:
                             dist_threshold,
                         )
                     elif dist_type == 'hamming':
+                        if dist_threshold >= 1.0:
+                            # make the distance threshold intuitive
+                            dist_threshold /= series.shape[0]
                         future = executor.submit(
                             hierarchical_clustering,
                             target_df,


### PR DESCRIPTION
- tsdr: pass parameters with **kwargs
- tsdr: refactor prepare_services_list
- tsdr: add typing for aggregate_metrics
- tsdr: wrap tsdr processing code as class Tsdr
- tsdr: enable to replace function for detecting anomaly of univariate series
- tsdr: remove unit_root_model param
- tsdr: enable to specify model combination
- tsdr: fixed forgotten change reflection in test code
- tsdr: give typing whenever possible
- tools: skip image generation if neptune.mode == debug
- tsdr: refactor the details
- tests: add white noise series in test code
- tsdr: enable to take log in unit_root_based_model
- tests: enable to discover the param combinations where all cases are passed
- notebooks: update
- tsdr: add an option for taking log
- tests: add post_cv variations
- tsdr: use AR lag as knn's window size
- notebooks: update
- tsdr: fix trivial issues in knn
- tsdr: update default config
- notebooks: try hotteling t2 to distinguish white noise and short spike
- tsdr: support hotteling t2 as post_od_model
- tools: support post_od_model params
- tsdr: remove 'import re'
- conf: increase distance threshold in step2
- notebooks: add ar-based anomaly detection
- tsdr: add ar-based outlier detector
- notebooks: update
- tsdr: enable ar outlier detector to pass datasets
- tsdr: prepare ar_based_ad_model func
- tools,conf: enable to choose ar based ad model
- tests: add test for ar_abomaly_score
- notebooks,tests: visualize testcases
- tests: add ar_regression pytest param
- notebooks: dignose test failure
- tsdr: fix calculation of prediction error in AR model
- notebooks: update
- tsdr: fix param name
- tests: look for upper and lower thresholds
- tools: fix an issue where the script did not upload parameters to neptune
- tsdr: supress warnings generated in AR outlier detector
- tsdr: add missing typing
- tsdr: use time.perf_counter() to improve resolution
- tools: save elapsedTime of each test into neptune
- tsdr: still use absolute time
- tools: save elapsedTime as score into neptune
- tsdr: move tests.testseries -> tsdr.testseries
- tools: add script to verify tsdr univariate model
- tests: remove old test script
- kick to install depsin ci
- Revert "kick to install depsin ci"
- tests: add test for outlierdetection.ar
- tests: add test for outlierdetection.knn
- tests: add cache key to clear cache in github actions
- tests: fix that the test code didn't compare want and got
- tsdr: move cv filtering before running unit root test
- tools: display all rows of some dataframes
- tools: print the type of model
- tsdr: add include_nan option for ar.score()
- tsdr: add method to fit anomaly scores to chi2 distribution
- tsdr: use detect_by_fitting_dist in AR-based AD
- tsdr: fix the issue where it cannot pass tsifter_step1_ar_regression
- tools: rename
- tools: add utility script to get datapoints
- tsdr: fix typo
- tools: enable to print compact dictionary in get_datapoints
- tools: fix indent
- tsdr: perform clustering in each type of metric
- tests: fix test code not catched up the previous change in the body code
- use make test in CI
- tsdr: refactor to access predicted_mean member
- tsdr: use zip instead of enumerate
- tsdr: make scores passable in AR model
- tsdr: introduce UnivariateSeriesReductionResult to pass anomaly scores to step2
- tsdr: set step1: ar_based_ad as default
- tsdr: fill_value with float to fit the size of original series in AR
- tsdr: add option to enable anomaly score clustering
- tsdr: fixed forgotten change reflection in test code
- tests: arrange code
- tsdr: fix typing mismatch error
- tsdr: copy dataframe if use_anomaly_score
- tsdr: enable to upload plots image if it is 'debug'
- tsdr: adjust indentation
- tsdr: fix typing
- tools: adjust indentation
- tools: fix the unnesessary and additional index columns
- tools: remove argparse
- tools: adjust indentation
- tools: fix an issue where it could not upload anomaly score plots in clustered_metrics if use_anomaly_score
- tools: warp processing related image uploader as time series plotter
- clean packages in CI
- tests: fix test in test_ar
- tests: add test_ar_outlier_detector_detect
- fix an issue of the absence of pytest because --no-dev option in CI
- tsdr: remove zscore
- tsdr: enable to set deterministic lag for AR
- notebooks: begin to diagnose misdetected series in AR
- tsdr: add an option for dynamic prediction in AR model
- notebooks: add try and errors for misdetected series with AR model
- tools: add an option of ar_dynamic_prediction
- tests: fix test failure because of the interface change
- tools: fix the conditional branch using enable_upload_plots
- lib: extend ground truth of pod-memory-hog injection
- lib: extend ground truth of pod-cpu-hog injection
- tests: fix test failure
- update neptune-client to v0.14.3
- tsdr: remove unused import
- tsdr: fix compared positions in AR outlier detection
- tsdr: raise error if scores include inf becasue clustering raise error
- tsdr: use scipy.stats.zscore
- tsdr: add an option to transform pre-clustered series into binary-based anomaly scores
- tsdr: fix misisng to pass abn_th
- tsdr: fix type np.ndarray into float
- tsdr: add an option to use hamming distance in step2 clustering
