### PR TITLE
Add maxsum method of choosing representative metrics

### DIFF
--- a/conf/tsdr/step1/ar_based_ad.yaml
+++ b/conf/tsdr/step1/ar_based_ad.yaml
@@ -1,5 +1,5 @@
 model_name: ar_based_ad
-ar_regression: c
+ar_regression: n
 ar_anomaly_score_threshold: 0.01
 ar_dynamic_prediction: false
 cv_threshold: 0.05

--- a/conf/tsdr/step2/default.yaml
+++ b/conf/tsdr/step2/default.yaml
@@ -1,3 +1,4 @@
 dist_threshold: 0.01  # should be <1.0 if 'sbd' is specified
 clustered_series_type: 'raw' # 'raw', 'anomaly_score' or 'binary_anomaly_score'
 clustering_dist_type: 'sbd' # 'sbd' or 'hamming'
+clustering_choice_method: 'medoid'  # 'medoid' or 'maxsum'

--- a/conf/tsdr/step2/default.yaml
+++ b/conf/tsdr/step2/default.yaml
@@ -1,3 +1,3 @@
-dist_threshold: 0.01
+dist_threshold: 0.01  # should be <1.0 if 'sbd' is specified
 clustered_series_type: 'raw' # 'raw', 'anomaly_score' or 'binary_anomaly_score'
 clustering_dist_type: 'sbd' # 'sbd' or 'hamming'

--- a/tools/eval_tsdr.py
+++ b/tools/eval_tsdr.py
@@ -255,6 +255,7 @@ def eval_tsdr(run: neptune.Run, cfg: DictConfig):
                 'tsifter_step2_clustering_threshold': cfg.step2.dist_threshold,
                 'tsifter_step2_clustered_series_type': cfg.step2.clustered_series_type,
                 'tsifter_step2_clustering_dist_type': cfg.step2.clustering_dist_type,
+                'tsifter_step2_clustering_choice_method': cfg.step2.clustering_choice_method,
             }
             if cfg.step1.model_name == 'unit_root_test':
                 tsdr_param.update({
@@ -416,6 +417,7 @@ def main(cfg: DictConfig) -> None:
         'step2_dist_threshold': cfg.step2.dist_threshold,
         'step2_clustered_series_type': cfg.step2.clustered_series_type,
         'step2_clustering_dist_type': cfg.step2.clustering_dist_type,
+        'step2_clustering_choice_method': cfg.step2.clustering_choice_method,
     }
     if cfg.step1.model_name == 'unit_root_test':
         params.update({

--- a/tsdr/tsdr.py
+++ b/tsdr/tsdr.py
@@ -178,7 +178,7 @@ class Tsdr:
         metrics_dimension["total"].append(len(reduced_series1.columns))
 
         # step2
-        df_before_clustering: pd.DataFrame = pd.DataFrame()
+        df_before_clustering: pd.DataFrame
         series_type = self.params['tsifter_step2_clustered_series_type']
         if series_type == 'raw':
             df_before_clustering = reduced_series1
@@ -187,9 +187,11 @@ class Tsdr:
                 if res.has_kept:
                     df_before_clustering[name] = res.anomaly_scores
         elif series_type == 'binary_anomaly_score':
+            tmp_dict_to_df: dict[str, np.ndarray] = {}
             for name, res in step1_results.items():
                 if res.has_kept:
-                    df_before_clustering[name] = res.binary_scores()
+                    tmp_dict_to_df[name] = res.binary_scores()
+            df_before_clustering = pd.DataFrame(tmp_dict_to_df)
         else:
             raise ValueError(f'tsifter_step2_clustered_series_type is invalid {series_type}')
 

--- a/tsdr/tsdr.py
+++ b/tsdr/tsdr.py
@@ -316,6 +316,14 @@ def hierarchical_clustering(
         else:
             cluster_dict[v] = [i]
 
+    return choose_metric_with_medoid(target_df.columns, cluster_dict, dist_matrix)
+
+
+def choose_metric_with_medoid(
+    columns: pd.Index[str],
+    cluster_dict: dict[str, list[int]],
+    dist_matrix: np.ndarray,
+) -> tuple[dict[str, Any], list[str]]:
     clustering_info, remove_list = {}, []
     for c in cluster_dict:
         cluster_metrics = cluster_dict[c]
@@ -324,9 +332,9 @@ def hierarchical_clustering(
         if len(cluster_metrics) == 2:
             # Select the representative metric at random
             shuffle_list = random.sample(cluster_metrics, len(cluster_metrics))
-            clustering_info[target_df.columns[shuffle_list[0]]] = [
-                target_df.columns[shuffle_list[1]]]
-            remove_list.append(target_df.columns[shuffle_list[1]])
+            clustering_info[columns[shuffle_list[0]]] = [
+                columns[shuffle_list[1]]]
+            remove_list.append(columns[shuffle_list[1]])
         elif len(cluster_metrics) > 2:
             # Select medoid as the representative metric
             distances = []
@@ -338,13 +346,12 @@ def hierarchical_clustering(
                     dist_sum += dist_matrix[met1][met2]
                 distances.append(dist_sum)
             medoid = cluster_metrics[np.argmin(distances)]
-            clustering_info[target_df.columns[medoid]] = []
+            clustering_info[columns[medoid]] = []
             for r in cluster_metrics:
                 if r == medoid:
                     continue
-                remove_list.append(target_df.columns[r])
-                clustering_info[target_df.columns[medoid]].append(
-                    target_df.columns[r])
+                remove_list.append(columns[r])
+                clustering_info[columns[medoid]].append(columns[r])
     return clustering_info, remove_list
 
 

--- a/tsdr/tsdr.py
+++ b/tsdr/tsdr.py
@@ -182,15 +182,14 @@ class Tsdr:
         series_type = self.params['tsifter_step2_clustered_series_type']
         if series_type == 'raw':
             df_before_clustering = reduced_series1
-        elif series_type == 'anomaly_score':
-            for name, res in step1_results.items():
-                if res.has_kept:
-                    df_before_clustering[name] = res.anomaly_scores
-        elif series_type == 'binary_anomaly_score':
+        elif series_type in ['anomaly_score' or 'binary_anomaly_score']:
             tmp_dict_to_df: dict[str, np.ndarray] = {}
             for name, res in step1_results.items():
                 if res.has_kept:
-                    tmp_dict_to_df[name] = res.binary_scores()
+                    if series_type == 'anomaly_score':
+                        tmp_dict_to_df[name] = res.anomaly_scores()
+                    elif series_type == 'binary_anomaly_score':
+                        tmp_dict_to_df[name] = res.binary_scores()
             df_before_clustering = pd.DataFrame(tmp_dict_to_df)
         else:
             raise ValueError(f'tsifter_step2_clustered_series_type is invalid {series_type}')


### PR DESCRIPTION
- tsdr: pass parameters with **kwargs
- tsdr: refactor prepare_services_list
- tsdr: add typing for aggregate_metrics
- tsdr: wrap tsdr processing code as class Tsdr
- tsdr: enable to replace function for detecting anomaly of univariate series
- tsdr: remove unit_root_model param
- tsdr: enable to specify model combination
- tsdr: fixed forgotten change reflection in test code
- tsdr: give typing whenever possible
- tools: skip image generation if neptune.mode == debug
- tsdr: refactor the details
- tests: add white noise series in test code
- tsdr: enable to take log in unit_root_based_model
- tests: enable to discover the param combinations where all cases are passed
- notebooks: update
- tsdr: add an option for taking log
- tests: add post_cv variations
- tsdr: use AR lag as knn's window size
- notebooks: update
- tsdr: fix trivial issues in knn
- tsdr: update default config
- notebooks: try hotteling t2 to distinguish white noise and short spike
- tsdr: support hotteling t2 as post_od_model
- tools: support post_od_model params
- tsdr: remove 'import re'
- conf: increase distance threshold in step2
- notebooks: add ar-based anomaly detection
- tsdr: add ar-based outlier detector
- notebooks: update
- tsdr: enable ar outlier detector to pass datasets
- tsdr: prepare ar_based_ad_model func
- tools,conf: enable to choose ar based ad model
- tests: add test for ar_abomaly_score
- notebooks,tests: visualize testcases
- tests: add ar_regression pytest param
- notebooks: dignose test failure
- tsdr: fix calculation of prediction error in AR model
- notebooks: update
- tsdr: fix param name
- tests: look for upper and lower thresholds
- tools: fix an issue where the script did not upload parameters to neptune
- tsdr: supress warnings generated in AR outlier detector
- tsdr: add missing typing
- tsdr: use time.perf_counter() to improve resolution
- tools: save elapsedTime of each test into neptune
- tsdr: still use absolute time
- tools: save elapsedTime as score into neptune
- tsdr: move tests.testseries -> tsdr.testseries
- tools: add script to verify tsdr univariate model
- tests: remove old test script
- kick to install depsin ci
- Revert "kick to install depsin ci"
- tests: add test for outlierdetection.ar
- tests: add test for outlierdetection.knn
- tests: add cache key to clear cache in github actions
- tests: fix that the test code didn't compare want and got
- tsdr: move cv filtering before running unit root test
- tools: display all rows of some dataframes
- tools: print the type of model
- tsdr: add include_nan option for ar.score()
- tsdr: add method to fit anomaly scores to chi2 distribution
- tsdr: use detect_by_fitting_dist in AR-based AD
- tsdr: fix the issue where it cannot pass tsifter_step1_ar_regression
- tools: rename
- tools: add utility script to get datapoints
- tsdr: fix typo
- tools: enable to print compact dictionary in get_datapoints
- tools: fix indent
- tsdr: perform clustering in each type of metric
- tests: fix test code not catched up the previous change in the body code
- use make test in CI
- tsdr: refactor to access predicted_mean member
- tsdr: use zip instead of enumerate
- tsdr: make scores passable in AR model
- tsdr: introduce UnivariateSeriesReductionResult to pass anomaly scores to step2
- tsdr: set step1: ar_based_ad as default
- tsdr: fill_value with float to fit the size of original series in AR
- tsdr: add option to enable anomaly score clustering
- tsdr: fixed forgotten change reflection in test code
- tests: arrange code
- tsdr: fix typing mismatch error
- tsdr: copy dataframe if use_anomaly_score
- tsdr: enable to upload plots image if it is 'debug'
- tsdr: adjust indentation
- tsdr: fix typing
- tools: adjust indentation
- tools: fix the unnesessary and additional index columns
- tools: remove argparse
- tools: adjust indentation
- tools: fix an issue where it could not upload anomaly score plots in clustered_metrics if use_anomaly_score
- tools: warp processing related image uploader as time series plotter
- clean packages in CI
- tests: fix test in test_ar
- tests: add test_ar_outlier_detector_detect
- fix an issue of the absence of pytest because --no-dev option in CI
- tsdr: remove zscore
- tsdr: enable to set deterministic lag for AR
- notebooks: begin to diagnose misdetected series in AR
- tsdr: add an option for dynamic prediction in AR model
- notebooks: add try and errors for misdetected series with AR model
- tools: add an option of ar_dynamic_prediction
- tests: fix test failure because of the interface change
- tools: fix the conditional branch using enable_upload_plots
- lib: extend ground truth of pod-memory-hog injection
- lib: extend ground truth of pod-cpu-hog injection
- tests: fix test failure
- update neptune-client to v0.14.3
- tsdr: remove unused import
- tsdr: fix compared positions in AR outlier detection
- tsdr: raise error if scores include inf becasue clustering raise error
- tsdr: use scipy.stats.zscore
- tsdr: add an option to transform pre-clustered series into binary-based anomaly scores
- tsdr: fix misisng to pass abn_th
- tsdr: fix type np.ndarray into float
- tsdr: add an option to use hamming distance in step2 clustering
- tsdr: fix an mistake occured by because of the just before merge
- tsdr: make dist_threshold configuration intutive
- tsdr: fix test failure in AR
- tsdr: update default config
- tsdr: cut choice of metrics to function
- tsdr: add an option of the methods of choosing a representative metric in a cluster
- tsdr: improve performance of creating dataframe in binary_anomaly_score clustering
